### PR TITLE
Typing and consts updates

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -148,7 +148,7 @@ export interface ResourceCollectionWithItems<T> extends ResourceCollection {
  * Returns a collection of a particular resource from a Redux store, populating it with the correct items, in
  * the right order.
  */
-export interface GetCollectionFunction<T> { (currentState: ResourceReduxState<T>, params: object | string): ResourceCollectionWithItems<T> }
+export interface GetCollectionFunction<T> { (currentState: ResourceReduxState<T>, params?: object | string): ResourceCollectionWithItems<T> }
 
 /**
  * The type of Redux action that is emitted when that action occurs

--- a/index.d.ts
+++ b/index.d.ts
@@ -59,6 +59,11 @@ export const COMPLETE: string;
 export const PREVIEW: string;
 
 /**
+ * The status used when an external API has errored
+ */
+export const NETWORK_ERROR: string;
+
+/**
  * One of the statuses a resource item or resource collection can be in
  */
 export type StatusType = string;

--- a/index.d.ts
+++ b/index.d.ts
@@ -210,6 +210,11 @@ export interface ResourcesDefinition<T> {
     getItem: GetItemFunction<T>,
 
     /**
+     * Function that returns the new item of a resource type
+     */
+    getNewItem: GetItemFunction<T>,
+
+    /**
      * Function that returns a particular collection of resources
      */
     getCollection: GetCollectionFunction<T>

--- a/index.d.ts
+++ b/index.d.ts
@@ -68,6 +68,11 @@ export type StatusType = string;
  */
 export interface ResourceStatus {
     type: StatusType | null;
+    httpCode?: number,
+    error?: {
+        type: string;
+        occurredAt: number;
+    }
 }
 
 /**

--- a/src/action-creators/helpers/makeRequest.js
+++ b/src/action-creators/helpers/makeRequest.js
@@ -2,6 +2,7 @@ import isObject from '../../utils/object/isObject';
 import requestProgress from '../requestProgress';
 import { DOWN, UP } from '../../constants/ProgressDirections';
 import without from '../../utils/collection/without';
+import { NETWORK_ERROR } from '../../constants/NetworkStatuses';
 
 /**
  * Performs a HTTP request to an external API endpoint, based on the configuration options provided
@@ -317,7 +318,7 @@ function makeRequest(options, actionCreatorOptions = {}) {
             actionCreatorOptions,
             0,
             {
-              type: 'NETWORK_ERROR',
+              type: NETWORK_ERROR,
               occurredAt: Date.now(),
               ...(error || {})
             }
@@ -346,7 +347,7 @@ function makeRequest(options, actionCreatorOptions = {}) {
                   actionCreatorOptions,
                   0,
                   {
-                    type: 'NETWORK_ERROR',
+                    type: NETWORK_ERROR,
                     occurredAt: Date.now(),
                     ...(error || {})
                   }

--- a/src/constants/NetworkStatuses.js
+++ b/src/constants/NetworkStatuses.js
@@ -1,0 +1,9 @@
+/**
+ * The status used when an external API request has errorred at the network level
+ * @type {string}
+ */
+const NETWORK_ERROR = 'NETWORK_ERROR';
+
+export {
+  NETWORK_ERROR,
+};

--- a/src/index.js
+++ b/src/index.js
@@ -6,4 +6,6 @@ export { COMPLETE, PREVIEW } from './constants/ProjectionTypes';
 
 export { NEW, EDITING, FETCHING, CREATING, UPDATING, DESTROYING, DESTROY_ERROR, SUCCESS, PROGRESS, ERROR } from './constants/Statuses';
 
+export { NETWORK_ERROR } from './constants/NetworkStatuses';
+
 export { default as resources } from './resources';


### PR DESCRIPTION
This PR adds some missing typing information from the ResourceStatus when a network error occurs, as well as exporting NETWORK_ERROR as a const.