### PR TITLE
🐛 Fix an issue with the resource item status

### DIFF
--- a/src/actions/RESTful/editItem.js
+++ b/src/actions/RESTful/editItem.js
@@ -114,6 +114,8 @@ function reducer(resources, action) {
       ...item.values
     };
 
+    persistStatus(currentItem, item);
+
     const newStatus = function () {
       if (currentItem.status.dirty) {
 
@@ -152,6 +154,22 @@ function reducer(resources, action) {
       }
     };
   }
+}
+
+/**
+ * Helper function used to update the a new item to persist relevant status properties.
+ * @param {ITEM} currentItem 
+ * @param {ITEM} newItem
+ * @returns void
+ */
+function persistStatus(currentItem, newItem) {
+  const { syncedAt, requestedAt } = currentItem.status;
+
+  newItem.status = {
+    ...newItem.status,
+    syncedAt,
+    requestedAt,
+  };
 }
 
 export default {


### PR DESCRIPTION
The PR fixes an issue compromising integrity of the resource item status.
The 'syncedAt' property on the item status is used by the 'isNew' method to assess whether an item is already present in the database.
The 'editItem.js' 's 'editNewOrExistingItem' method does not persist the status which compromises the item’s integrity and in turn the result of the 'isNew' method call once an item has been edited.