### PR TITLE
🐛 Fix metadata not being pulled out from resources upon response

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "@rollup/plugin-replace": "^2.3.2",
     "@types/jasmine": "^3.5.10",
     "@types/whatwg-fetch": "^0.0.33",
-    "cross-env": "^7.0.2",
+    "cross-env": "^7.0.3",
     "eslint": "^7.1.0",
     "fetch-mock": "^9.10.1",
     "husky": "^4.2.5",

--- a/src/actions/RESTful/fetchItem.js
+++ b/src/actions/RESTful/fetchItem.js
@@ -125,15 +125,20 @@ function requestResource(options, actionCreatorOptions) {
 function receiveResource(options, actionCreatorOptions, values, metadata = {}) {
   const { transforms, action, params, keyBy, singular } = options;
 
+  const { metadata: itemMetadata, ...itemValues } = values;
+
   const item = applyTransforms(transforms, options, actionCreatorOptions, {
     ...ITEM,
-    values,
+    values: itemValues,
     status: { type: SUCCESS, syncedAt: Date.now() },
 
     /**
      * metadata from a responseAdaptor (if applicable) to be merged in with the existing metadata
      */
-    metadata,
+    metadata: {
+      ...metadata,
+      ...itemMetadata,
+    },
   });
 
   const normalizedParams = wrapInObject(params, keyBy);

--- a/src/actions/RESTful/fetchList.js
+++ b/src/actions/RESTful/fetchList.js
@@ -147,11 +147,16 @@ function receiveList(options, actionCreatorOptions, list, metadata) {
      */
     positions.push(itemKey);
 
+    const { metadata: itemsMetadata, ...itemValues } = values;
+
     memo[itemKey] = applyTransforms(transforms, options, actionCreatorOptions, {
       ...ITEM,
-      values,
+      values: itemValues,
       status: { type: SUCCESS, requestedAt, syncedAt },
-      metadata: actionCreatorOptions.itemsMetadata || options.metadata || {},
+      metadata: {
+        ...actionCreatorOptions.itemsMetadata || options.metadata || {},
+        ...itemsMetadata,
+      }
     });
 
     return memo;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1467,10 +1467,10 @@ cosmiconfig@^6.0.0:
     path-type "^4.0.0"
     yaml "^1.7.2"
 
-cross-env@^7.0.2:
-  version "7.0.2"
-  resolved "https://registry.yarnpkg.com/cross-env/-/cross-env-7.0.2.tgz#bd5ed31339a93a3418ac4f3ca9ca3403082ae5f9"
-  integrity sha512-KZP/bMEOJEDCkDQAyRhu3RL2ZO/SUVrxQVI0G3YEQ+OLbRA3c6zgixe8Mq8a/z7+HKlNEjo8oiLUs8iRijY2Rw==
+cross-env@^7.0.3:
+  version "7.0.3"
+  resolved "https://registry.yarnpkg.com/cross-env/-/cross-env-7.0.3.tgz#865264b29677dc015ba8418918965dd232fc54cf"
+  integrity sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==
   dependencies:
     cross-spawn "^7.0.1"
 


### PR DESCRIPTION
When a resource has metadata inside the object which is then passed into the redux store, the metadata isn't stripped out and applied to the metadata part of ResourcesItem. Instead it remains part of the object.

Currently we get this
`
{
  metadata: undefined,
  values: {
    name: 'car name',
    metadata: {
      manualUrl: 'DUMMY URL'
    }
  }
}
`

But we should get
`
{
  metadata: {
    manualUrl: 'DUMMY URL'
  },
  values: {
    name: 'car name'
  }
}
`